### PR TITLE
Keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,22 @@
-# zabbix-bash-completion
+======================
+Zabbix Bash Completion
+======================
+
 Bash completion for Zabbix commands
 
 To try this out, source the file. For example:
 
     . zabbix_get-completion
     zabbix_get -<tab><tab>
+    
+Also key completion for standard agent items is available. For example:
+
+    zabbix_get -k system.<tab><tab>
+    system.boottime       system.hw.chassis[    system.swap.out[
+    system.cpu.discovery  system.hw.cpu[        system.swap.size[
+    system.cpu.intr       system.hw.devices[    system.sw.arch
+    system.cpu.load[      system.hw.macaddr[    system.sw.os[
+    system.cpu.num[       system.localtime[     system.sw.packages[
+    system.cpu.switches   system.run[           system.uname
+    system.cpu.util[      system.stat[          system.uptime
+    system.hostname[      system.swap.in[       system.users.num

--- a/zabbix_get-completion
+++ b/zabbix_get-completion
@@ -17,6 +17,15 @@ _zabbix_get()
 	nonunique_opts="-s|-p|-I|-k|--host|--port|--source-address|--key"
 	unique_opts_space=${unique_opts//|/ }
 	nonunique_opts_space=${nonunique_opts//|/ }
+	keys="agent.hostname agent.ping agent.version kernel.maxfiles kernel.maxproc log[ logrt[ net.dns[ net.dns.record[ \
+		net.if.collisions[ net.if.discovery net.if.in[ net.if.out[ net.if.total[ net.tcp.listen[ net.tcp.port[ net.tcp.service[ \
+		net.tcp.service.perf[ net.udp.listen[ proc.mem[ proc.num[ sensor[ system.boottime system.cpu.discovery system.cpu.intr \
+		system.cpu.load[ system.cpu.num[ system.cpu.switches system.cpu.util[ system.hostname[ system.hw.chassis[ system.hw.cpu[ \
+		system.hw.devices[ system.hw.macaddr[ system.localtime[ system.run[ system.stat[ system.sw.arch system.sw.os[ \
+		system.sw.packages[ system.swap.in[ system.swap.out[ system.swap.size[ system.uname system.uptime system.users.num \
+		vfs.dev.read[ vfs.dev.write[ vfs.file.cksum[ vfs.file.contents[ vfs.file.exists[ vfs.file.md5sum[ vfs.file.regexp[ \
+		vfs.file.regmatch[ vfs.file.size[ vfs.file.time[ vfs.fs.discovery vfs.fs.inode[ vfs.fs.size[ vm.memory.size[ \
+		web.page.get[ web.page.perf[ web.page.regexp[ eventlog[ net.if.list perf_counter[ proc_info[ service_state[ services[ wmi.get["    
 
 	opts=" $unique_opts_space $nonunique_opts_space "
 	for (( i=1; i<=${#COMP_WORDS[@]-1}; ++i )) ; do
@@ -57,7 +66,11 @@ _zabbix_get()
 			COMPREPLY=( $(compgen -W "$(ip -o addr show | awk '{sub(/\/.*/,"",$4); print $4}')" -- ${cur}) )
 			return 0
 			;;
-		-@(p|-port|k|-key))
+		-@(k|-key))
+			COMPREPLY=($(compgen -W "${keys}" -- ${cur}))
+			return 0
+			;;
+		-@(p|-port))
 			return 1
 			;;
 		*)

--- a/zabbix_get-completion
+++ b/zabbix_get-completion
@@ -17,7 +17,7 @@ _zabbix_get()
 	nonunique_opts="-s|-p|-I|-k|--host|--port|--source-address|--key"
 	unique_opts_space=${unique_opts//|/ }
 	nonunique_opts_space=${nonunique_opts//|/ }
-	keys="agent.hostname agent.ping agent.version kernel.maxfiles kernel.maxproc log[ logrt[ net.dns[ net.dns.record[ \
+	keys="agent.hostname agent.ping agent.version kernel.maxfiles kernel.maxproc net.dns[ net.dns.record[ \
 		net.if.collisions[ net.if.discovery net.if.in[ net.if.out[ net.if.total[ net.tcp.listen[ net.tcp.port[ net.tcp.service[ \
 		net.tcp.service.perf[ net.udp.listen[ proc.mem[ proc.num[ sensor[ system.boottime system.cpu.discovery system.cpu.intr \
 		system.cpu.load[ system.cpu.num[ system.cpu.switches system.cpu.util[ system.hostname[ system.hw.chassis[ system.hw.cpu[ \
@@ -68,6 +68,9 @@ _zabbix_get()
 			;;
 		-@(k|-key))
 			COMPREPLY=($(compgen -W "${keys}" -- ${cur}))
+			if [[ $COMPREPLY =~ "[" ]] ; then
+				compopt -o nospace
+			fi
 			return 0
 			;;
 		-@(p|-port))


### PR DESCRIPTION
Keys completion added - source manual 2.4 zabbix agent items - except log items (because they are available only in active mode - good point @richlv ). Keys with parameter(s) don't have space at the end now.
