### PR TITLE
Log items removed from zabbix_agentd -t completion

### DIFF
--- a/zabbix_agentd-completion
+++ b/zabbix_agentd-completion
@@ -81,7 +81,7 @@ _zabbix_agentd()
 			;;
 		-@(t|-test))
 			# get the available item keys (without parameters) from the currently used binary
-			COMPREPLY=( $(compgen -W "$($1 -p | awk '/\[/ {sub(/\[.*/,"[",$1);print $1}')" -- ${cur}) )
+			COMPREPLY=( $(compgen -W "$($1 -p | awk '/\[/ && !/^log/ {sub(/\[.*/,"[",$1);print $1}')" -- ${cur}) )
 			if [[ $COMPREPLY =~ "[" ]]; then
 				compopt -o nospace
 			fi


### PR DESCRIPTION
They are accessible only as active check only:

```
zabbix_agentd -t log[/etc/hosts]
log[/etc/hosts]                               [m|ZBX_NOTSUPPORTED] [Accessible only as active check.]
```
